### PR TITLE
add show for other platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist-js
+/target/
+Cargo.lock

--- a/src/spotlight_others.rs
+++ b/src/spotlight_others.rs
@@ -53,6 +53,7 @@ impl SpotlightManager {
 
     pub fn show(&self, window: &Window<Wry>) -> Result<(), Error> {
         if !window.is_visible().map_err(|_| Error::FailedToCheckWindowVisibility)? {
+            window.show().map_err(|_| Error::FailedToShowWindow)?;
             window.set_focus().map_err(|_| Error::FailedToShowWindow)?;
         }
         Ok(())


### PR DESCRIPTION
window.set_focus() is not sufficient on Windows. I added window.show() before window.set_focus().

closes #1 