### PR TITLE
Emit message on hide/show for macos

### DIFF
--- a/src/spotlight_macos/spotlight.rs
+++ b/src/spotlight_macos/spotlight.rs
@@ -115,8 +115,12 @@ fn register_shortcut_for_window(window: &Window<Wry>, window_config: &WindowConf
         let manager = app_handle.state::<SpotlightManager>();
         if window.is_visible().unwrap() {
             manager.hide(&window).unwrap();
+            // Emit a message when the window is shown
+            window.emit("spotlight-window-hidden", {}).unwrap();
         } else {
             manager.show(&window).unwrap();
+            // Emit a message when the window is shown
+            window.emit("spotlight-window-shown", {}).unwrap();
         }
     }).map_err(|_| Error::Other(String::from("failed to register shortcut")))?;
     Ok(())


### PR DESCRIPTION
This is useful to focus a text input when shown. I thought this may be useful to others so opened a pull request here :)