### PR TITLE
feat: Update dependencies and configurations for MacOS

### DIFF
--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -61,8 +61,8 @@ jobs:
             ./examples/react-app/src-tauri
 
       - name: build frontend api, the plugin
-        run: \
-          pnpm i && \
+        run: |
+          pnpm install && \
           pnpm build
         # change this to npm or pnpm depending on which one you use.
 

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -1,0 +1,84 @@
+name: "Publish Examples"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "pnpm" # Set this to npm, yarn or pnpm.
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ./
+            ./examples/react-app/src-tauri
+
+      - name: build frontend api, the plugin
+        run: \
+          pnpm i && \
+          pnpm build
+        # change this to npm or pnpm depending on which one you use.
+
+      - name: install dependencies of example app
+        # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
+        run: |
+          cd examples/react-app && \
+          pnpm install
+        # change this to npm or pnpm depending on which one you use.
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: "App v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 jobs:
   publish-tauri:

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: build frontend api, the plugin
         run: |
-          pnpm install && \
+          pnpm install
           pnpm build
         # change this to npm or pnpm depending on which one you use.
 
       - name: install dependencies of example app
         # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
         run: |
-          cd examples/react-app && \
+          cd examples/react-app
           pnpm install
         # change this to npm or pnpm depending on which one you use.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,8 +299,24 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -366,7 +382,20 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -686,7 +715,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -694,6 +744,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2509,9 +2565,9 @@ dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
  "cc",
- "cocoa",
+ "cocoa 0.24.1",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dispatch",
  "gdk",
@@ -2582,7 +2638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd27c04b9543776a972c86ccf70660b517ecabbeced9fb58d8b961a13ad129af"
 dependencies = [
  "anyhow",
- "cocoa",
+ "cocoa 0.24.1",
  "dirs-next",
  "embed_plist",
  "encoding_rs",
@@ -2664,7 +2720,7 @@ name = "tauri-plugin-spotlight"
 version = "0.2.0"
 dependencies = [
  "bitflags 2.4.2",
- "cocoa",
+ "cocoa 0.25.0",
  "objc",
  "objc-foundation",
  "objc_id",
@@ -2701,7 +2757,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cae61fbc731f690a4899681c9052dde6d05b159b44563ace8186fc1bfb7d158"
 dependencies = [
- "cocoa",
+ "cocoa 0.24.1",
  "gtk",
  "percent-encoding",
  "rand 0.8.5",
@@ -3505,8 +3561,8 @@ checksum = "6ad85d0e067359e409fcb88903c3eac817c392e5d638258abfb3da5ad8ba6fc4"
 dependencies = [
  "base64 0.13.1",
  "block",
- "cocoa",
- "core-graphics",
+ "cocoa 0.24.1",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dunce",
  "gdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ tauri = { version = "1.2", features = ["global-shortcut-all"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bitflags = "2.4.2"
-objc-foundation = "0.1.1"
 objc_id = "0.1.1"
 thiserror = "1.0.56"
 
 [target."cfg(target_os = \"macos\")".dependencies]
-cocoa = { version = "0.24.1" }
-objc =  { version = "0.2.7" }
+cocoa = { version = "0.25.0" }
+objc = { version = "0.2.7" }
+objc-foundation = "0.1.1"

--- a/examples/react-app/src-tauri/Cargo.lock
+++ b/examples/react-app/src-tauri/Cargo.lock
@@ -309,8 +309,24 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -376,7 +392,20 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -710,7 +739,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -718,6 +768,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1133,6 +1189,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2295,6 +2357,7 @@ version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
+ "indexmap 2.2.2",
  "itoa 1.0.10",
  "ryu",
  "serde",
@@ -2560,9 +2623,9 @@ dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
  "cc",
- "cocoa",
+ "cocoa 0.24.1",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dispatch",
  "gdk",
@@ -2628,21 +2691,23 @@ checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tauri"
-version = "1.5.4"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd27c04b9543776a972c86ccf70660b517ecabbeced9fb58d8b961a13ad129af"
+checksum = "336bc661a3f3250853fa83c6e5245449ed1c26dce5dcb28bdee7efedf6278806"
 dependencies = [
  "anyhow",
- "cocoa",
+ "cocoa 0.24.1",
  "dirs-next",
+ "dunce",
  "embed_plist",
  "encoding_rs",
  "flate2",
  "futures-util",
+ "getrandom 0.2.12",
  "glib",
  "glob",
  "gtk",
- "heck 0.4.1",
+ "heck 0.5.0",
  "http",
  "ignore",
  "objc",
@@ -2694,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1554c5857f65dbc377cefb6b97c8ac77b1cb2a90d30d3448114d5d6b48a77fc"
+checksum = "c1aed706708ff1200ec12de9cfbf2582b5d8ec05f6a7293911091effbd22036b"
 dependencies = [
  "base64 0.21.7",
  "brotli",
@@ -2720,11 +2785,11 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277abf361a3a6993ec16bcbb179de0d6518009b851090a01adfea12ac89fa875"
+checksum = "b88f831d2973ae4f81a706a0004e67dac87f2e4439973bbe98efbd73825d8ede"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2737,7 +2802,7 @@ name = "tauri-plugin-spotlight"
 version = "0.2.0"
 dependencies = [
  "bitflags 2.4.2",
- "cocoa",
+ "cocoa 0.25.0",
  "objc",
  "objc-foundation",
  "objc_id",
@@ -2749,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2d0652aa2891ff3e9caa2401405257ea29ab8372cce01f186a5825f1bd0e76"
+checksum = "3068ed62b63dedc705558f4248c7ecbd5561f0f8050949859ea0db2326f26012"
 dependencies = [
  "gtk",
  "http",
@@ -2770,11 +2835,11 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.14.3"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cae61fbc731f690a4899681c9052dde6d05b159b44563ace8186fc1bfb7d158"
+checksum = "d4c3db170233096aa30330feadcd895bf9317be97e624458560a20e814db7955"
 dependencies = [
- "cocoa",
+ "cocoa 0.24.1",
  "gtk",
  "percent-encoding",
  "rand 0.8.5",
@@ -2790,15 +2855,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece74810b1d3d44f29f732a7ae09a63183d63949bbdd59c61f8ed2a1b70150db"
+checksum = "2826db448309d382dac14d520f0c0a40839b87b57b977e59cf5f296b3ace6a93"
 dependencies = [
  "brotli",
  "ctor",
  "dunce",
  "glob",
- "heck 0.4.1",
+ "heck 0.5.0",
  "html5ever",
  "infer",
  "json-patch",
@@ -3692,14 +3757,14 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.24.7"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad85d0e067359e409fcb88903c3eac817c392e5d638258abfb3da5ad8ba6fc4"
+checksum = "00711278ed357350d44c749c286786ecac644e044e4da410d466212152383b45"
 dependencies = [
  "base64 0.13.1",
  "block",
- "cocoa",
- "core-graphics",
+ "cocoa 0.24.1",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dunce",
  "gdk",

--- a/examples/react-app/src-tauri/src/main.rs
+++ b/examples/react-app/src-tauri/src/main.rs
@@ -11,18 +11,19 @@ fn greet(name: &str) -> String {
 
 fn main() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_spotlight::init(Some(tauri_plugin_spotlight::PluginConfig {
-            windows: Some(vec![
-                tauri_plugin_spotlight::WindowConfig {
+        .plugin(tauri_plugin_spotlight::init(Some(
+            tauri_plugin_spotlight::PluginConfig {
+                windows: Some(vec![tauri_plugin_spotlight::WindowConfig {
                     label: String::from("main"),
                     shortcut: String::from("Ctrl+Shift+J"),
                     macos_window_level: None,
-                },
-            ]),
-            global_close_shortcut: Some(String::from("Escape")),
-        })))
+                }]),
+                global_close_shortcut: Some(String::from("Escape")),
+            },
+        )))
         .invoke_handler(tauri::generate_handler![greet])
         .setup(|app| {
+            #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             Ok(())
         })

--- a/examples/react-app/src-tauri/tauri.conf.json
+++ b/examples/react-app/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.tauri.dev",
+      "identifier": "com.zzzze.tauri-plugin-spotlight",
       "longDescription": "",
       "macOS": {
         "entitlements": null,
@@ -104,10 +104,12 @@
   },
   "plugins": {
     "spotlight": {
-      "windows": [{
-        "label": "secondary",
-        "shortcut": "Ctrl+Shift+K"
-      }],
+      "windows": [
+        {
+          "label": "secondary",
+          "shortcut": "Ctrl+Shift+K"
+        }
+      ],
       "global_close_shortcut": "Escape"
     }
   }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,27 +44,28 @@ impl PluginConfig {
                     Some(windows)
                 }
             },
-            global_close_shortcut: a.global_close_shortcut.clone().or(b.global_close_shortcut.clone()),
+            global_close_shortcut: a
+                .global_close_shortcut
+                .clone()
+                .or(b.global_close_shortcut.clone()),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::WindowConfig;
     use super::PluginConfig;
+    use super::WindowConfig;
 
     #[test]
     fn merge_and_override_default_value() {
         let a = PluginConfig::default();
         let b = PluginConfig {
-            windows: Some(vec![
-                WindowConfig {
-                    label: String::from("main"),
-                    shortcut: String::from("Ctrl+I"),
-                    macos_window_level: None,
-                },
-            ]),
+            windows: Some(vec![WindowConfig {
+                label: String::from("main"),
+                shortcut: String::from("Ctrl+I"),
+                macos_window_level: None,
+            }]),
             global_close_shortcut: Some(String::from("Escape")),
         };
         let c = PluginConfig::merge(&a, &b);
@@ -74,41 +75,40 @@ mod tests {
     #[test]
     fn merge_windows() {
         let a = PluginConfig {
-            windows: Some(vec![
-                WindowConfig {
-                    label: String::from("main"),
-                    shortcut: String::from("Ctrl+I"),
-                    macos_window_level: None,
-                },
-            ]),
+            windows: Some(vec![WindowConfig {
+                label: String::from("main"),
+                shortcut: String::from("Ctrl+I"),
+                macos_window_level: None,
+            }]),
             global_close_shortcut: None,
         };
         let b = PluginConfig {
-            windows: Some(vec![
-                WindowConfig {
-                    label: String::from("foo"),
-                    shortcut: String::from("bar"),
-                    macos_window_level: None,
-                },
-            ]),
+            windows: Some(vec![WindowConfig {
+                label: String::from("foo"),
+                shortcut: String::from("bar"),
+                macos_window_level: None,
+            }]),
             global_close_shortcut: None,
         };
         let c = PluginConfig::merge(&a, &b);
-        assert_eq!(c, PluginConfig {
-            windows: Some(vec![
-                WindowConfig {
-                    label: String::from("main"),
-                    shortcut: String::from("Ctrl+I"),
-                    macos_window_level: None,
-                },
-                WindowConfig {
-                    label: String::from("foo"),
-                    shortcut: String::from("bar"),
-                    macos_window_level: None,
-                },
-            ]),
-            global_close_shortcut: None,
-        });
+        assert_eq!(
+            c,
+            PluginConfig {
+                windows: Some(vec![
+                    WindowConfig {
+                        label: String::from("main"),
+                        shortcut: String::from("Ctrl+I"),
+                        macos_window_level: None,
+                    },
+                    WindowConfig {
+                        label: String::from("foo"),
+                        shortcut: String::from("bar"),
+                        macos_window_level: None,
+                    },
+                ]),
+                global_close_shortcut: None,
+            }
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
+mod config;
+mod error;
 #[cfg_attr(target_os = "macos", path = "spotlight_macos/mod.rs")]
 #[cfg_attr(not(target_os = "macos"), path = "spotlight_others.rs")]
 mod spotlight;
-mod error;
-mod config;
 
 pub use config::{PluginConfig, WindowConfig};
 pub use error::Error;
 
 use tauri::{
     plugin::{Builder, TauriPlugin},
-    Manager, Wry, Runtime, State, Window
+    Manager, Runtime, State, Window, Wry,
 };
 
 pub trait ManagerExt<R: Runtime> {
@@ -17,18 +17,24 @@ pub trait ManagerExt<R: Runtime> {
 }
 
 impl<R: Runtime, T: Manager<R>> ManagerExt<R> for T {
-  fn spotlight(&self) -> State<'_, spotlight::SpotlightManager> {
-    self.state::<spotlight::SpotlightManager>()
-  }
+    fn spotlight(&self) -> State<'_, spotlight::SpotlightManager> {
+        self.state::<spotlight::SpotlightManager>()
+    }
 }
 
 #[tauri::command]
-fn show(manager: State<'_, spotlight::SpotlightManager>, window: Window<Wry>) -> Result<(), String> {
+fn show(
+    manager: State<'_, spotlight::SpotlightManager>,
+    window: Window<Wry>,
+) -> Result<(), String> {
     manager.show(&window).map_err(|err| format!("{:?}", err))
 }
 
 #[tauri::command]
-fn hide(manager: State<'_, spotlight::SpotlightManager>, window: Window<Wry>) -> Result<(), String> {
+fn hide(
+    manager: State<'_, spotlight::SpotlightManager>,
+    window: Window<Wry>,
+) -> Result<(), String> {
     manager.hide(&window).map_err(|err| format!("{:?}", err))
 }
 
@@ -36,17 +42,18 @@ pub fn init(spotlight_config: Option<PluginConfig>) -> TauriPlugin<Wry, Option<P
     Builder::<Wry, Option<PluginConfig>>::new("spotlight")
         .invoke_handler(tauri::generate_handler![show, hide])
         .setup_with_config(|app, config| {
-            app.manage(spotlight::SpotlightManager::new(
-                PluginConfig::merge(
-                    &spotlight_config.unwrap_or(PluginConfig::default()),
-                    &config.unwrap_or(PluginConfig::default()),
-                )
-            ));
+            app.manage(spotlight::SpotlightManager::new(PluginConfig::merge(
+                &spotlight_config.unwrap_or(PluginConfig::default()),
+                &config.unwrap_or(PluginConfig::default()),
+            )));
             Ok(())
         })
         .on_webview_ready(move |window| {
             let app_handle = window.app_handle();
-            app_handle.spotlight().init_spotlight_window(&window).unwrap();
+            app_handle
+                .spotlight()
+                .init_spotlight_window(&window)
+                .unwrap();
         })
         .build()
 }

--- a/src/spotlight_macos/panel.rs
+++ b/src/spotlight_macos/panel.rs
@@ -1,10 +1,13 @@
 use core::fmt;
 
 use bitflags::bitflags;
-use objc_id::{Id, ShareId};
 use cocoa::{
-    appkit::{NSMainMenuWindowLevel, NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindowCollectionBehavior},
-    base::{id, nil, BOOL, YES}, foundation::NSRect,
+    appkit::{
+        NSMainMenuWindowLevel, NSView, NSViewHeightSizable, NSViewWidthSizable,
+        NSWindowCollectionBehavior,
+    },
+    base::{id, nil, BOOL, YES},
+    foundation::NSRect,
 };
 use objc::{
     class,
@@ -14,6 +17,7 @@ use objc::{
     sel, sel_impl, Message,
 };
 use objc_foundation::INSObject;
+use objc_id::{Id, ShareId};
 use tauri::{Window, Wry};
 
 extern "C" {

--- a/src/spotlight_others.rs
+++ b/src/spotlight_others.rs
@@ -1,9 +1,7 @@
-use std::sync::Mutex;
-use tauri::{
-    GlobalShortcutManager, Manager, Window, WindowEvent, Wry,
-};
-use super::{PluginConfig, WindowConfig};
 use super::Error;
+use super::{PluginConfig, WindowConfig};
+use std::sync::Mutex;
+use tauri::{GlobalShortcutManager, Manager, Window, WindowEvent, Wry};
 
 #[derive(Default, Debug)]
 pub struct SpotlightManager {
@@ -52,7 +50,10 @@ impl SpotlightManager {
     }
 
     pub fn show(&self, window: &Window<Wry>) -> Result<(), Error> {
-        if !window.is_visible().map_err(|_| Error::FailedToCheckWindowVisibility)? {
+        if !window
+            .is_visible()
+            .map_err(|_| Error::FailedToCheckWindowVisibility)?
+        {
             window.show().map_err(|_| Error::FailedToShowWindow)?;
             window.set_focus().map_err(|_| Error::FailedToShowWindow)?;
         }
@@ -60,25 +61,33 @@ impl SpotlightManager {
     }
 
     pub fn hide(&self, window: &Window<Wry>) -> Result<(), Error> {
-        if window.is_visible().map_err(|_| Error::FailedToCheckWindowVisibility)? {
+        if window
+            .is_visible()
+            .map_err(|_| Error::FailedToCheckWindowVisibility)?
+        {
             window.hide().map_err(|_| Error::FailedToHideWindow)?;
         }
         Ok(())
     }
 }
 
-fn register_shortcut_for_window(window: &Window<Wry>, window_config: &WindowConfig) -> Result<(), Error> {
+fn register_shortcut_for_window(
+    window: &Window<Wry>,
+    window_config: &WindowConfig,
+) -> Result<(), Error> {
     let window = window.to_owned();
     let mut shortcut_manager = window.app_handle().global_shortcut_manager();
-    shortcut_manager.register(&window_config.shortcut, move || {
-        let app_handle = window.app_handle();
-        let manager = app_handle.state::<SpotlightManager>();
-        if window.is_visible().unwrap() {
-            manager.hide(&window).unwrap();
-        } else {
-            manager.show(&window).unwrap();
-        }
-    }).map_err(|_| Error::Other(String::from("failed to register shortcut")))?;
+    shortcut_manager
+        .register(&window_config.shortcut, move || {
+            let app_handle = window.app_handle();
+            let manager = app_handle.state::<SpotlightManager>();
+            if window.is_visible().unwrap() {
+                manager.hide(&window).unwrap();
+            } else {
+                manager.show(&window).unwrap();
+            }
+        })
+        .map_err(|_| Error::Other(String::from("failed to register shortcut")))?;
     Ok(())
 }
 
@@ -90,18 +99,20 @@ fn register_close_shortcut(window: &Window<Wry>) -> Result<(), Error> {
     if let Some(close_shortcut) = &manager.config.global_close_shortcut {
         if let Ok(registered) = shortcut_manager.is_registered(close_shortcut) {
             if !registered {
-                shortcut_manager.register(close_shortcut, move || {
-                    let app_handle = window.app_handle();
-                    let state = app_handle.state::<SpotlightManager>();
-                    let registered_window = state.registered_window.lock().unwrap();
-                    let window_labels = registered_window.clone();
-                    std::mem::drop(registered_window);
-                    for label in window_labels {
-                        if let Some(window) = app_handle.get_window(&label) {
-                            window.hide().unwrap();
+                shortcut_manager
+                    .register(close_shortcut, move || {
+                        let app_handle = window.app_handle();
+                        let state = app_handle.state::<SpotlightManager>();
+                        let registered_window = state.registered_window.lock().unwrap();
+                        let window_labels = registered_window.clone();
+                        std::mem::drop(registered_window);
+                        for label in window_labels {
+                            if let Some(window) = app_handle.get_window(&label) {
+                                window.hide().unwrap();
+                            }
                         }
-                    }
-                }).map_err(tauri::Error::Runtime)?;
+                    })
+                    .map_err(tauri::Error::Runtime)?;
             }
         } else {
             return Err(Error::Other(String::from("failed to register shortcut")));
@@ -118,7 +129,9 @@ fn unregister_close_shortcut(window: &Window<Wry>) -> Result<(), Error> {
     if let Some(close_shortcut) = manager.config.global_close_shortcut.clone() {
         if let Ok(registered) = shortcut_manager.is_registered(&close_shortcut) {
             if registered {
-                shortcut_manager.unregister(&close_shortcut).map_err(tauri::Error::Runtime)?;
+                shortcut_manager
+                    .unregister(&close_shortcut)
+                    .map_err(tauri::Error::Runtime)?;
             }
         } else {
             return Err(Error::Other(String::from("failed to unregister shortcut")));


### PR DESCRIPTION
- Update cocoa dependency to version 0.25.0
- Add support for customizing window level in MacOS
- Use panel with NSWindowStyleMaskNonActivatingPanel style on MacOS
- Rename 'close_shortcut' option to 'global_close_shortcut'
- Remove 'hide_when_inactive' option from configuration
- Fix crash caused by null pointer when hiding spotlight window